### PR TITLE
Fixing comments from bleeding over newlines.

### DIFF
--- a/roy-mode.el
+++ b/roy-mode.el
@@ -43,7 +43,7 @@
 
 ;;;###autoload
 (define-generic-mode 'roy-mode
-  '("//.*\n") ;; comments
+  '("//[^\r\n]*\n") ;; comments
   roy-keywords
   '(;; fixnums
     ("[0-9]+" . 'font-lock-variable-name-face)


### PR DESCRIPTION
.\* is greedy, so it was eating up newlines and causing everything after a single comment to be coloured as a comment.
